### PR TITLE
fix: allow HTTP for Tailscale endpoints

### DIFF
--- a/src/shared/util-llm-endpoint.ts
+++ b/src/shared/util-llm-endpoint.ts
@@ -115,6 +115,7 @@ export function isPrivateNetworkHost(hostname) {
     if (octets.some(n => n < 0 || n > 255)) return false;
     const [a, b] = octets;
     return a === 10
+      || (a === 100 && b >= 64 && b <= 127)
       || a === 127
       || (a === 172 && b >= 16 && b <= 31)
       || (a === 192 && b === 168)


### PR DESCRIPTION
## What changed

Treat the RFC 6598 shared address space (`100.64.0.0/10`) as a private-network endpoint when validating service URLs.

## Why

Tailscale assigns devices addresses from this range. LexVoice currently classifies HTTP transcription endpoints on those addresses as public and rejects them with the requirement to use HTTPS.

The root cause is that `isPrivateNetworkHost` covers RFC 1918, loopback, link-local, and private IPv6 ranges, but omits the RFC 6598 range.

## Impact

- HTTP/WS endpoints on `100.64.0.0/10` are accepted, enabling Tailscale-hosted transcription and LLM services.
- Other public HTTP/WS endpoints remain blocked and still require HTTPS/WSS.

## Validation

- Confirmed the change is limited to the shared private-network classifier.
- Ran `git diff --check` successfully.
- Build and automated tests were not run.
